### PR TITLE
Add list options

### DIFF
--- a/lib/object-storage.js
+++ b/lib/object-storage.js
@@ -176,6 +176,11 @@ ObjectStorage.prototype.copy = function (srcObj, dstObj) {
  * @return {Promise}	Resolves with response body
  */
 ObjectStorage.prototype.list = function (container, opts) {
+	if (typeof container === 'object') {
+		// when container is omitted but opts is given
+		opts = container;
+		container = '';
+	}
 	container = container || '';
 	var optString = opts ? '?' + querystring.stringify(opts) : '';
 


### PR DESCRIPTION
As the storage stores more objects, the size of the list of the objects also increase. Therefore the filter of list is needed. So, I added options of the list command.

usage:

```
storage.list('mycontainer', { prefix: 'IMG_', limit: 20})
    .then(function(result) {
        console.log(JSON.parse(result));
    });
```

Available options are limit, marker, end_marker, prefix, format, delimiter and path. Details are in http://docs.openstack.org/api/openstack-object-storage/1.0/content/GET_showContainerDetails_v1__account___container__storage_container_services.html
