### PR TITLE
handling both 'application/json' and 'application/json; charset=utf-8'

### DIFF
--- a/lib/object-storage.js
+++ b/lib/object-storage.js
@@ -187,7 +187,7 @@ ObjectStorage.prototype.list = function (container, opts) {
 	return this.request().spread(function (req, url) {
 		return req.get(url + slash(container) + optString)
 			.end().then(function (res) {
-				if (res.headers['content-type'] === 'application/json') {
+				if (/^application\/json($|;)/.test(res.headers['content-type'])) {
 					return JSON.parse(res.body);
 				}
 				return res.body;


### PR DESCRIPTION
My storage server sends 'application/json; charset=utf-8' for content-type headers.
