### PR TITLE
fix backslash path when running on Windows

### DIFF
--- a/lib/object-storage.js
+++ b/lib/object-storage.js
@@ -2,8 +2,7 @@
 var Promise = require('bluebird'),
 	request = require('request'),
 	ObjectStorageRequest = require('./object-storage-request'),
-	querystring = require('querystring'),
-	joinPath = require('path').join;
+	querystring = require('querystring');
 
 function slash(path) {
 	return (path[0] === '/') ? path : '/' + path;


### PR DESCRIPTION
One of my co-worker meeted an error while he worked on the Windows machine.

```
Possibly unhandled Error: PUT https://myobjectstorage.domain.com/v1/somepath\myContainerName responded with statusCode: 400, body:
```

The main reason is that `path.join()` used in the `slash()` converts `/`s to `\`s when it runs on Windows. I think that the node.js `path` is designed for local path.
