### PR TITLE
add error event handler for the uploading local files

### DIFF
--- a/lib/object-storage-request.js
+++ b/lib/object-storage-request.js
@@ -120,7 +120,9 @@ ObjectStorageRequest.prototype.end = function () {
 	};
 
 	if (this.attachment) {
-		fs.createReadStream(this.attachment).pipe(request(opts, handleResponse));
+		fs.createReadStream(this.attachment).on('error', function(err) {
+            dfd.reject(err);
+        }).pipe(request(opts, handleResponse));
 	} else {
 		request(opts, handleResponse);
 	}

--- a/lib/object-storage-request.js
+++ b/lib/object-storage-request.js
@@ -120,7 +120,7 @@ ObjectStorageRequest.prototype.end = function () {
 	};
 
 	if (this.attachment) {
-		fs.createReadStream(this.attachment).on('error', function(err) {
+		fs.createReadStream(this.attachment).on('error', function (err) {
             dfd.reject(err);
         }).pipe(request(opts, handleResponse));
 	} else {


### PR DESCRIPTION
Add error event handler to the local file read stream.
For some errors, such as ‘file not exists’, the Promise will return error object by callback, instead of throwing it.
